### PR TITLE
Granular selection of elements to grab.

### DIFF
--- a/src/lib/extract/extract-admin-role.ts
+++ b/src/lib/extract/extract-admin-role.ts
@@ -1,0 +1,33 @@
+import { api } from "../api";
+import writeToFile from "../utils/write-to-file";
+import filterFields from "../utils/filter-fields";
+
+const systemFields = [
+  "id",
+  "name"
+];
+
+/**
+ * Extract roles from the API
+ */
+export default async function extractAdminRole(dir: string) {
+  try {
+    const { data }: { data: any } = await api.get("/roles", {
+      params: {
+        limit: "-1",
+        filter: {
+          "name": {
+            "_eq": "Administrator"
+          }
+        }
+      },
+    });
+
+    const filteredData = filterFields(data.data, systemFields);
+
+    // Use the dynamic dir parameter
+    await writeToFile("admin-role", filteredData, dir);
+  } catch (error) {
+    console.log("Error extracting Roles:", error.response.data.errors);
+  }
+}

--- a/src/lib/extract/index.ts
+++ b/src/lib/extract/index.ts
@@ -11,9 +11,10 @@ import extractUsers from "./extract-users";
 import extractRoles from "./extract-roles";
 import extractFiles from "./extract-files";
 import extractPresets from "./extract-presets";
+import extractAdminRole from "./extract-admin-role";
 
 export const aspects = {
-  "schema and collections" : async (destination:string) => {
+  "schema" : async (destination:string) => {
     await extractSchema( destination );
   },
   "roles and permission" : async (destination:string) => {
@@ -51,6 +52,10 @@ export default async function extract(dir: string, cli: any) {
     console.log(`Attempting to create directory at: ${destination}`);
     fs.mkdirSync(destination, { recursive: true });
   }
+
+  //We need to make sure that we do have the admin role!
+  await extractAdminRole(destination);
+
   for (const key of cli.selectedAspects) {
     const callback = aspects[key]
     console.log(`Fetching ${key}`)

--- a/src/lib/extract/index.ts
+++ b/src/lib/extract/index.ts
@@ -15,7 +15,6 @@ import extractPresets from "./extract-presets";
 export const aspects = {
   "schema and collections" : async (destination:string) => {
     await extractSchema( destination );
-    await extractFromEndpoint( "collections", destination );
   },
   "roles and permission" : async (destination:string) => {
     await extractRoles( destination );
@@ -35,6 +34,7 @@ export const aspects = {
     await extractFromEndpoint( "panels", destination );
   },
   "content" : async (destination:string) => {
+    await extractFromEndpoint( "collections", destination );
     await extractFiles( destination );
     await downloadAllFiles( destination );
     await extractFolders( destination );

--- a/src/lib/load/index.ts
+++ b/src/lib/load/index.ts
@@ -26,19 +26,21 @@ export default async function apply(dir: string, cli: any) {
   }
   
 
-  // Role Loading Logic
-  // Several other elements depend on roles being present, to know about the old and new adminRoleID. 
-  // Why are roles UUIDed anyway? Seems like something that could use a slug. What do I know...
-  //if ( checkPath("roles", source) ){
-    const roles = readFile("roles", source);
-    const legacyAdminRoleId = roles.find(
+
+  //Read adminrole
+  const adminRole = readFile("admin-role", source);
+  const legacyAdminRoleId = adminRole.find(
       (role) => role.name === "Administrator"
-    ).id;
-    const currentUser = await api.get<any>("users/me");
-    const newAdminRoleId = currentUser.data.data.role;
+  ).id;
+  const currentUser = await api.get<any>("users/me");
+  const newAdminRoleId = currentUser.data.data.role;
+
+  // Role Loading Logic
+  if ( checkPath("roles", source) ){
+    const roles = readFile("roles", source);
     await loadRoles(roles);
     cli.log("Loaded Roles");
-  //}
+  }
 
   if ( checkPath("folders", source) ){
     await loadFolders(source);

--- a/src/lib/load/index.ts
+++ b/src/lib/load/index.ts
@@ -1,5 +1,6 @@
 import { api } from "../api";
 import readFile from "../utils/read-file";
+import { checkPath } from "../utils/read-file";
 import loadToDestination from "../utils/load-to-destination";
 import loadSchema from "./load-schema";
 import loadRoles from "./load-roles";
@@ -19,55 +20,77 @@ export default async function apply(dir: string, cli: any) {
   const source = dir + "/src";
 
   // Load the template files into the destination
-  await loadSchema(source + "/schema");
-  cli.log("Loaded Schema");
+  if ( checkPath("schema/snapshot", source) ){
+    await loadSchema(source + "/schema");
+    cli.log("Loaded Schema");
+  }
+  
 
   // Role Loading Logic
-  const roles = readFile("roles", source);
-  const legacyAdminRoleId = roles.find(
-    (role) => role.name === "Administrator"
-  ).id;
-  const currentUser = await api.get<any>("users/me");
-  const newAdminRoleId = currentUser.data.data.role;
-  await loadRoles(roles);
-  cli.log("Loaded Roles");
+  // Several other elements depend on roles being present, to know about the old and new adminRoleID. 
+  // Why are roles UUIDed anyway? Seems like something that could use a slug. What do I know...
+  //if ( checkPath("roles", source) ){
+    const roles = readFile("roles", source);
+    const legacyAdminRoleId = roles.find(
+      (role) => role.name === "Administrator"
+    ).id;
+    const currentUser = await api.get<any>("users/me");
+    const newAdminRoleId = currentUser.data.data.role;
+    await loadRoles(roles);
+    cli.log("Loaded Roles");
+  //}
 
-  await loadFolders(source);
-  cli.log("Loaded Folders");
+  if ( checkPath("folders", source) ){
+    await loadFolders(source);
+    cli.log("Loaded Folders");
+  }
+  if ( checkPath("files", source) ){
+    await loadFiles(readFile("files", source), source); // Comes after folders
+    cli.log("Loaded Files");
+  }
 
-  await loadFiles(readFile("files", source), source); // Comes after folders
-  cli.log("Loaded Files");
-  await loadUsers(readFile("users", source), legacyAdminRoleId, newAdminRoleId); // Comes after roles, files
-  cli.log("Loaded Users");
+  if ( checkPath("users", source) ){
+    await loadUsers(readFile("users", source), legacyAdminRoleId, newAdminRoleId); // Comes after roles, files
+    cli.log("Loaded Users");
+  }
+  if ( checkPath("dashboard", source) ){
+    await loadDashboards(readFile("dashboards", source));
+    cli.log("Loaded Dashboards");
 
-  await loadDashboards(readFile("dashboards", source));
-  cli.log("Loaded Dashboards");
+    await loadToDestination("panels", readFile("panels", source)); // Comes after dashboards
+    cli.log("Loaded Panels");
+  }
 
-  await loadToDestination("panels", readFile("panels", source)); // Comes after dashboards
-  cli.log("Loaded Panels");
+  if ( checkPath("collections", source) ){
+    await loadData(readFile("collections", source), source);
+    cli.log("Loaded Data");
+  }
 
-  await loadData(readFile("collections", source), source);
-  cli.log("Loaded Data");
+  if ( checkPath("flows", source) ){
+    // Loading Flows and Operations after data so we don't trigger the flows on the data we're loading
+    await loadFlows(readFile("flows", source));
+    cli.log("Loaded Flows");
 
-  // Loading Flows and Operations after data so we don't trigger the flows on the data we're loading
-  await loadFlows(readFile("flows", source));
-  cli.log("Loaded Flows");
+    await loadOperations(readFile("operations", source)); // Comes after flows
+    cli.log("Loaded Operations");
+  }
 
-  await loadOperations(readFile("operations", source)); // Comes after flows
-  cli.log("Loaded Operations");
+  if ( checkPath("presets", source) ){
+    await loadPresets(readFile("presets", source));
+    cli.log("Loaded Presets");
+  }
 
-  await loadPresets(readFile("presets", source));
-  cli.log("Loaded Presets");
-
-  await loadSettings(readFile("settings", source));
-  cli.log("Loaded Settings");
+  if ( checkPath("settings", source) ){
+    await loadSettings(readFile("settings", source));
+    cli.log("Loaded Settings");
+  }
 
   await loadPermissions(
     readFile("permissions", source),
     legacyAdminRoleId,
     newAdminRoleId
   );
-
   cli.log("Loaded Permissions");
+
   return {};
 }

--- a/src/lib/utils/auth.ts
+++ b/src/lib/utils/auth.ts
@@ -3,7 +3,7 @@ import { api } from "../api";
 import validateUrl from "./validate-url";
 
 export async function getDirectusUrl() {
-  const directusUrl = await ux.prompt("What is your Directus URL?");
+  const directusUrl = await ux.prompt("What is your Directus URL?", {default:"http://localhost:8055"});
   // Validate URL
   if (!validateUrl(directusUrl)) {
     ux.warn("Invalid URL");

--- a/src/lib/utils/read-file.ts
+++ b/src/lib/utils/read-file.ts
@@ -10,3 +10,7 @@ export function readJsonFile(path: string): any[] {
   const obj = JSON.parse(f)
   return obj
 }
+
+export function checkPath(file: string, dir:string): boolean {
+  return fs.existsSync( `${dir}/${file}.json` );
+}


### PR DESCRIPTION
This PR implements a granular choise of which elements to extract from a project. They are grouped in to elements that do in fact make sense. i.E. Roles and Permissions should always be fetched together.

The adminRole will be fetched non the less, as there are several elements that do rely on it.

Updating settings might fail, when content (including files) is not fetched. Same should be true for users which rely on avatars or similiar. (User should not be pushed anyway imho.)