### PR TITLE
feat: pass flags in extract and apply command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,50 @@ The CLI can also extract a template from a Directus instance so that it can be a
 $ npx directus-template-cli@latest extract
 ```
 
+## Extract Command
+
+To extract a template named `name` from a directory `data/backup`, use the following command:
+
+```
+./bin/dev cli extract
+    --templateName name
+    --directory data/backup
+    --directusUrl https://www.example.com
+    --directusToken xxxxxx
+```
+
+
+### Parameters:
+
+- `--templateName`: The name of the template you wish to extract.
+- `--directory`: The path to the directory where the template will be extracted.
+- `--directusUrl`: The URL of your Directus instance.
+- `--directusToken`: An authentication token for accessing your Directus instance.
+
+
+
+## Apply Command
+
+To apply a locally stored template located at `data/backup` to your Directus instance, use the following command:
+
+```
+./bin/dev cli apply
+    --templateType local-cli
+    --templateLocation data/backup
+    --directusUrl https://www.example.com
+    --directusToken xxxxxx
+```
+
+
+### Parameters:
+
+- `--templateType`: The type of the template you wish to apply (e.g., `local-cli`).
+- `--templateLocation`: The path to the directory where the template is stored.
+- `--directusUrl`: The URL of your Directus instance.
+- `--directusToken`: An authentication token for accessing your Directus instance.
+
+
+
 ## License
 
 This tool is licensed under the [MIT License](https://opensource.org/licenses/MIT).

--- a/src/commands/cli/apply.ts
+++ b/src/commands/cli/apply.ts
@@ -1,0 +1,160 @@
+import {Command, ux, Flags} from '@oclif/core'
+import {downloadTemplate} from 'giget'
+import * as inquirer from 'inquirer'
+import path from 'node:path'
+
+import apply from '../../lib/load/'
+import {getDirectusToken, getDirectusUrl} from '../../lib/utils/auth'
+import logError from '../../lib/utils/log-error'
+import openUrl from '../../lib/utils/open-url'
+import resolvePathAndCheckExistence from '../../lib/utils/path'
+import {readAllTemplates, readTemplate} from '../../lib/utils/read-templates'
+import {transformGitHubUrl} from '../../lib/utils/transform-github-url'
+
+const separator = '------------------'
+
+async function getTemplate(tType?: string, tLocation?: string) {
+  let templateType: any;
+  if (tType && tLocation && tType == 'local-cli') {
+    templateType = {
+      templateType: tType, 
+      templateLocation: tLocation
+    }
+  } else {
+    templateType = await inquirer.prompt([
+      {
+        choices: [
+          {
+            name: 'Community templates',
+            value: 'community',
+          },
+          {
+            name: 'From a local directory',
+            value: 'local',
+          },
+          {
+            name: 'From a public GitHub repository',
+            value: 'github',
+          },
+          {
+            name: 'Get premium templates',
+            value: 'directus-plus',
+          },
+        ],
+        message: 'What type of template would you like to apply?',
+        name: 'templateType',
+        type: 'list',
+      },
+    ])
+  }
+
+  let template: any
+
+  if (templateType.templateType === 'local') {
+    let localTemplateDir = await ux.prompt(
+      'What is the local template directory?',
+    )
+
+    localTemplateDir = resolvePathAndCheckExistence(localTemplateDir)
+
+    if (localTemplateDir) {
+      template = {template: await readTemplate(localTemplateDir)}
+    } else {
+      ux.error('Directory does not exist.')
+    }
+  }
+
+  if (templateType.templateType === 'local-cli') {
+    let localTemplateDir = resolvePathAndCheckExistence(templateType.templateLocation)
+
+    if (localTemplateDir) {
+      template = {template: await readTemplate(localTemplateDir)}
+    } else {
+      ux.error('Directory does not exist.')
+    }
+  }
+
+  if (templateType.templateType === 'github') {
+    const ghTemplateUrl = await ux.prompt('What is the public GitHub repository URL?')
+
+    try {
+      const ghString = await transformGitHubUrl(ghTemplateUrl)
+
+      // Resolve the path for downloading
+      const downloadDir = resolvePathAndCheckExistence(path.join(__dirname, '..', 'downloads', 'github'), false)
+      if (!downloadDir) {
+        throw new Error(`Invalid download directory: ${path.join(__dirname, '..', 'downloads', 'github')}`)
+      }
+
+      // Download the template
+      const {dir} = await downloadTemplate(ghString, {
+        dir: downloadDir,
+        force: true,
+        forceClean: true,
+      })
+
+      // Check if the directory exists after download
+      const resolvedDir = resolvePathAndCheckExistence(dir)
+      if (!resolvedDir) {
+        throw new Error(`Downloaded template directory does not exist: ${dir}`)
+      }
+
+      template = {template: await readTemplate(dir)}
+    } catch (error) {
+      logError(error, {fatal: true})
+    }
+  }
+
+  if (templateType.templateType === 'directus-plus') {
+    openUrl('https://directus.io/plus?utm_source=directus-template-cli&utm_content=apply-command')
+    ux.log('Redirecting to Directus website.')
+    ux.exit(0)
+  }
+
+  return template
+}
+
+export default class ApplyCommand extends Command {
+  static description = 'Apply a template to a blank Directus instance.'
+
+  static examples = ['$ directus-template-cli apply']
+
+  static flags = {
+    templateType: Flags.string(),
+    templateLocation: Flags.string(),
+    directusUrl: Flags.string(),
+    directusToken: Flags.string(),
+  }
+
+  public async run(): Promise<void> {
+    const {flags} = await this.parse(ApplyCommand)
+    const chosenTemplate = await getTemplate(flags.templateType, flags.templateLocation)
+    ux.log(`You selected ${chosenTemplate.template.templateName}`)
+
+    ux.log(separator)
+
+    const directusUrl = await getDirectusUrl(flags.directusUrl)
+    const directusToken = await getDirectusToken(directusUrl, flags.directusToken);
+    if (!directusToken) {
+      this.log('Invalid credentials. Please try again.');
+      this.exit(1);
+    }
+
+    ux.log(separator)
+
+    // Run load script
+    ux.log(
+      `Applying template - ${chosenTemplate.template.templateName} to ${directusUrl}`,
+    )
+
+    await apply(chosenTemplate.template.directoryPath)
+
+    ux.action.stop()
+
+    ux.log(separator)
+
+    ux.log('Template applied successfully.')
+
+    ux.exit(0)
+  }
+}

--- a/src/commands/cli/extract.ts
+++ b/src/commands/cli/extract.ts
@@ -1,0 +1,78 @@
+import {Command, ux, Flags} from '@oclif/core';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import extract from '../../lib/extract';
+import {getDirectusToken, getDirectusUrl} from '../../lib/utils/auth';
+import {
+  generatePackageJsonContent,
+  generateReadmeContent,
+} from '../../lib/utils/template-defaults';
+
+const separator = '------------------';
+
+export default class ExtractCommand extends Command {
+  static description = 'Extract a template from a Directus instance.';
+  static flags = {
+    templateName: Flags.string(),
+    directory: Flags.string(),
+    directusUrl: Flags.string(),
+    directusToken: Flags.string(),
+  };
+
+  static examples = ['$ directus-template-cli extract'];
+
+  public async run(): Promise<void> {
+    const {flags} = await this.parse(ExtractCommand)
+    if (!flags.templateName || !flags.directory || !flags.directusUrl || !flags.directusToken) {
+      this.log('Missing required flags: --templateName, --directory, --directusUrl, --directusToken')
+      this.exit(1)
+    }
+
+    this.log(`You selected ${flags.directory}`);
+    try {
+      // Check if directory exists, if not, then create it.
+      if (!fs.existsSync(flags.directory)) {
+        fs.mkdirSync(flags.directory, {recursive: true});
+      }
+
+      // Create package.json and README.md
+      const packageJSONContent = generatePackageJsonContent(flags.templateName);
+      const readmeContent = generateReadmeContent(flags.templateName);
+
+      // Write the content to the specified directory
+      const packageJSONPath = path.join(flags.directory, 'package.json');
+      const readmePath = path.join(flags.directory, 'README.md');
+
+      fs.writeFileSync(packageJSONPath, packageJSONContent);
+      fs.writeFileSync(readmePath, readmeContent);
+    } catch (error) {
+      console.error(`Failed to create directory or write files: ${error.message}`);
+    }
+
+    this.log(separator);
+
+    // Assuming getDirectusToken and getDirectusUrl do not require user interaction
+    const directusUrl = await getDirectusUrl(flags.directusUrl)
+    const directusToken = await getDirectusToken(directusUrl, flags.directusToken);
+    if (!directusToken) {
+      this.log('Invalid credentials. Please try again.');
+      this.exit(1);
+    }
+
+    this.log(separator);
+
+    // Run the extract script
+    ux.action.start(`Extracting template - from ${directusUrl} to ${flags.directory}`);
+
+    await extract(flags.directory);
+
+    ux.action.stop();
+
+    this.log(separator);
+
+    this.log('Template extracted successfully.');
+
+    this.exit(0);
+  }
+}

--- a/src/lib/utils/auth.ts
+++ b/src/lib/utils/auth.ts
@@ -4,22 +4,30 @@ import {ux} from '@oclif/core'
 import {api} from '../sdk'
 import validateUrl from './validate-url'
 
-export async function getDirectusUrl() {
-  const directusUrl = await ux.prompt('What is your Directus URL?', {default: 'http://localhost:8055'})
+export async function getDirectusUrl(directusUrl?: string) {
+
+  let isFlagProvided = directusUrl !== undefined;
+  if (!directusUrl) {
+    directusUrl = await ux.prompt('What is your Directus URL?', {default: 'http://localhost:8055'})
+  }
 
   // Validate URL
   if (!validateUrl(directusUrl)) {
-    ux.warn('Invalid URL')
-    return getDirectusUrl()
+    ux.warn('Invalid URL');
+    if (isFlagProvided) return;
+    return getDirectusUrl();
   }
 
-  api.initialize(directusUrl)
+  api.initialize(directusUrl);
 
-  return directusUrl
+  return directusUrl;
 }
 
-export async function getDirectusToken(directusUrl: string) {
-  const directusToken = await ux.prompt('What is your Directus Admin Token?')
+export async function getDirectusToken(directusUrl: string, directusToken?: string) {
+  let isFlagProvided = directusToken !== undefined
+  if (!directusToken) {
+    directusToken = await ux.prompt('What is your Directus Admin Token?')
+  }
 
   // Validate token
   try {
@@ -28,8 +36,9 @@ export async function getDirectusToken(directusUrl: string) {
     ux.log(`Logged in as ${response.first_name} ${response.last_name}`)
     return directusToken
   } catch (error) {
-    console.log(error)
-    ux.warn('Invalid token. Please try again.')
+    if (!isFlagProvided) {
+      ux.warn('Invalid token. Please try again.')
+    } else return;
     return getDirectusToken(directusUrl)
   }
 }


### PR DESCRIPTION
## Extract Command

To extract a template named `name` from a directory `data/backup`, use the following command:

```
./bin/dev cli extract
    --templateName name
    --directory data/backup
    --directusUrl https://www.example.com
    --directusToken xxxxxx
```


### Parameters:

- `--templateName`: The name of the template you wish to extract.
- `--directory`: The path to the directory where the template will be extracted.
- `--directusUrl`: The URL of your Directus instance.
- `--directusToken`: An authentication token for accessing your Directus instance.



## Apply Command

To apply a locally stored template located at `data/backup` to your Directus instance, use the following command:

```
./bin/dev cli apply
    --templateType local-cli
    --templateLocation data/backup
    --directusUrl https://www.example.com
    --directusToken xxxxxx
```


### Parameters:

- `--templateType`: The type of the template you wish to apply (e.g., `local-cli`).
- `--templateLocation`: The path to the directory where the template is stored.
- `--directusUrl`: The URL of your Directus instance.
- `--directusToken`: An authentication token for accessing your Directus instance.
